### PR TITLE
[Vacgom-102] 육아 기록 아이템 아기 연관관계 추가

### DIFF
--- a/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
@@ -1,11 +1,15 @@
 package kr.co.vacgom.api.baby.application
 
 import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.exceptioin.BabyError
 import kr.co.vacgom.api.baby.repository.BabyRepository
+import kr.co.vacgom.api.global.exception.error.BusinessException
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Service
+@Transactional
 class BabyService(
     private val babyRepository: BabyRepository
 ) {
@@ -15,5 +19,9 @@ class BabyService(
 
     fun getBabiesById(babyIds: List<UUID>): List<Baby> {
         return babyRepository.findBabiesById(babyIds)
+    }
+
+    fun getBabyById(id: UUID): Baby {
+        return babyRepository.findById(id) ?: throw BusinessException(BabyError.BABY_NOT_FOUND)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
@@ -1,9 +1,7 @@
 package kr.co.vacgom.api.baby.application
 
 import kr.co.vacgom.api.baby.domain.Baby
-import kr.co.vacgom.api.baby.exceptioin.BabyError
 import kr.co.vacgom.api.baby.repository.BabyRepository
-import kr.co.vacgom.api.global.exception.error.BusinessException
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -22,6 +20,6 @@ class BabyService(
     }
 
     fun getBabyById(id: UUID): Baby {
-        return babyRepository.findById(id) ?: throw BusinessException(BabyError.BABY_NOT_FOUND)
+        return babyRepository.findById(id)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/baby/exceptioin/BabyError.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/exceptioin/BabyError.kt
@@ -1,14 +1,13 @@
-package kr.co.vacgom.api.user.exception
+package kr.co.vacgom.api.baby.exceptioin
 
 import kr.co.vacgom.api.global.exception.error.ErrorCode
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.NOT_FOUND
 
-enum class UserError(
+enum class BabyError(
     override val message: String,
     override val status: HttpStatus,
     override val code: String,
 ) : ErrorCode {
-    USER_NOT_FOUND("회원이 존재하지 않습니다.", NOT_FOUND, "U_001"),
-    SOCIAL_ID_NOT_FOUND("소셜 ID가 존재하지 않습니다.", NOT_FOUND, "U_002")
+    BABY_NOT_FOUND("아기가 존재하지 않습니다.", NOT_FOUND, "B_001"),
 }

--- a/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepository.kt
@@ -6,4 +6,5 @@ import java.util.*
 interface BabyRepository {
     fun saveAll(babies: List<Baby>): List<Baby>
     fun findBabiesById(ids: List<UUID>): List<Baby>
+    fun findById(id: UUID): Baby?
 }

--- a/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepository.kt
@@ -6,5 +6,5 @@ import java.util.*
 interface BabyRepository {
     fun saveAll(babies: List<Baby>): List<Baby>
     fun findBabiesById(ids: List<UUID>): List<Baby>
-    fun findById(id: UUID): Baby?
+    fun findById(id: UUID): Baby
 }

--- a/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepositoryAdapter.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/repository/BabyRepositoryAdapter.kt
@@ -1,6 +1,9 @@
 package kr.co.vacgom.api.baby.repository
 
 import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.exceptioin.BabyError
+import kr.co.vacgom.api.global.exception.error.BusinessException
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.util.*
 
@@ -12,5 +15,9 @@ class BabyRepositoryAdapter(private val babyJpaRepository: BabyJpaRepository): B
 
     override fun findBabiesById(ids: List<UUID>): List<Baby> {
         return babyJpaRepository.findAllById(ids)
+    }
+
+    override fun findById(id: UUID): Baby {
+        return babyJpaRepository.findByIdOrNull(id) ?: throw BusinessException(BabyError.BABY_NOT_FOUND)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/application/CareHistoryItemCreateService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/application/CareHistoryItemCreateService.kt
@@ -1,5 +1,6 @@
 package kr.co.vacgom.api.carehistoryitem.application
 
+import kr.co.vacgom.api.baby.application.BabyService
 import kr.co.vacgom.api.carehistoryitem.domain.*
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.presentation.dto.*
@@ -10,13 +11,16 @@ import java.time.temporal.ChronoUnit
 @Service
 class CareHistoryItemCreateService(
     private val careHistoryItemRepository: CareHistoryItemRepository,
+    private val babyService: BabyService,
 ) {
     fun addBreastFeeding(request: BreastFeedingDto.Request) {
+
         val newBreastFeeding = BreastFeeding(
             startTime = request.startDate,
             endTime = request.endDate,
             minutes = ChronoUnit.MINUTES.between(request.startDate, request.endDate).toInt(),
             breastDirection = request.breastDirection,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.BREAST_FEEDING
         )
@@ -27,6 +31,7 @@ class CareHistoryItemCreateService(
     fun addBabyFormula(request: BabyFormulaDto.Request) {
         val newBabyFormula = BabyFormula(
             amount = request.amount,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.BABY_FORMULA,
         )
@@ -37,6 +42,7 @@ class CareHistoryItemCreateService(
     fun addBreastPumping(request: BreastPumpingDto.Request) {
         val newBreastPumping = BreastPumping(
             amount = request.amount,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.BREAST_PUMPING
         )
@@ -47,6 +53,7 @@ class CareHistoryItemCreateService(
     fun addBabyFood(request: BabyFoodDto.Request) {
         val newBabyFood = BabyFood(
             amount = request.amount,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.BABY_FOOD
         )
@@ -57,6 +64,7 @@ class CareHistoryItemCreateService(
     fun addDiaper(request: DiaperDto.Request) {
         val newDiaper = Diaper(
             excrementType = request.excrementType,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.DIAPER,
         )
@@ -71,6 +79,7 @@ class CareHistoryItemCreateService(
             startTime = request.startDate,
             endTime = request.endDate,
             minutes = minutes,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.BATH
         )
@@ -85,6 +94,7 @@ class CareHistoryItemCreateService(
             startTime = request.startDate,
             endTime = request.endDate,
             minutes = minutes,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.SLEEP,
         )
@@ -96,6 +106,7 @@ class CareHistoryItemCreateService(
         val newHealth = Health(
             temperature = request.temperature,
             memo = request.memo,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.HEALTH,
         )
@@ -106,6 +117,7 @@ class CareHistoryItemCreateService(
     fun addSnack(request: SnackDto.Request) {
         val newSnack = Snack(
             memo = request.memo,
+            baby = babyService.getBabyById(request.babyId),
             executionTime = request.executionTime,
             itemType = CareHistoryItemType.SNACK,
         )

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFood.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFood.kt
@@ -3,6 +3,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.BABY_FOOD
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -15,9 +16,10 @@ import java.util.*
 class BabyFood(
     id: UUID = UuidCreator.create(),
     amount: Int,
+    baby: Baby,
     itemType: CareHistoryItemType = BABY_FOOD,
     executionTime: LocalDateTime,
-) : CareHistoryItem(id, executionTime, itemType) {
+) : CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 이유식 양")
     var amount = amount

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFormula.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFormula.kt
@@ -3,6 +3,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.BABY_FORMULA
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -15,9 +16,10 @@ import java.util.*
 class BabyFormula (
     id: UUID = UuidCreator.create(),
     amount: Int,
+    baby: Baby,
     itemType: CareHistoryItemType = BABY_FORMULA,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 분유 양")
     var amount = amount

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Bath.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Bath.kt
@@ -3,6 +3,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.BATH
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -19,6 +20,7 @@ class Bath (
     startTime: LocalDateTime,
     endTime: LocalDateTime,
     minutes: Int,
+    baby: Baby,
     itemType: CareHistoryItemType = BATH,
     executionTime: LocalDateTime,
 ): CareHistoryItem(id, executionTime, itemType) {

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Bath.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Bath.kt
@@ -23,7 +23,7 @@ class Bath (
     baby: Baby,
     itemType: CareHistoryItemType = BATH,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 목욕 시작 시간")
     var startTime: LocalDateTime = startTime

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastFeeding.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastFeeding.kt
@@ -1,6 +1,7 @@
 package kr.co.vacgom.api.carehistoryitem.domain
 
 import jakarta.persistence.*
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.BreastDirection
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.BREAST_FEEDING
@@ -17,9 +18,10 @@ class BreastFeeding (
     endTime: LocalDateTime,
     minutes: Int,
     breastDirection: BreastDirection,
+    baby: Baby,
     itemType: CareHistoryItemType = BREAST_FEEDING,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 모유수유 시작 시간")
     var startTime: LocalDateTime = startTime

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastPumping.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastPumping.kt
@@ -3,6 +3,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.BREAST_PUMPING
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -15,9 +16,10 @@ import java.util.*
 class BreastPumping (
     id: UUID = UuidCreator.create(),
     amount: Int,
+    baby: Baby,
     itemType: CareHistoryItemType = BREAST_PUMPING,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 유축 양")
     var amount = amount

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/CareHistoryItem.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/CareHistoryItem.kt
@@ -2,6 +2,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import jakarta.persistence.*
 import jakarta.persistence.InheritanceType.JOINED
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.global.common.domain.BaseTimeEntity
 import org.hibernate.annotations.Comment
@@ -15,6 +16,7 @@ abstract class CareHistoryItem(
     id: UUID,
     executionTime: LocalDateTime,
     itemType: CareHistoryItemType,
+    baby: Baby,
 ): BaseTimeEntity() {
     @Id
     @Column(name = "care_history_item_id", nullable = false, updatable = false, columnDefinition = "BINARY(16)")
@@ -33,5 +35,9 @@ abstract class CareHistoryItem(
     var executionTime: LocalDateTime = executionTime
         protected set
 
-    //Todo(용현) BabyId 외래키 추가 필요
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "baby_id", nullable = false)
+    @Comment("[Not Null] 아기 ID")
+    var baby: Baby = baby
+        protected set
 }

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Diaper.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Diaper.kt
@@ -1,6 +1,7 @@
 package kr.co.vacgom.api.carehistoryitem.domain
 
 import jakarta.persistence.*
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.DIAPER
 import kr.co.vacgom.api.carehistoryitem.domain.enums.ExcrementType
@@ -14,9 +15,10 @@ import java.util.*
 class Diaper (
     id: UUID = UuidCreator.create(),
     excrementType: ExcrementType,
+    baby: Baby,
     itemType: CareHistoryItemType = DIAPER,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Comment("[Not Null] 대소변 타입")

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Health.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Health.kt
@@ -2,6 +2,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.HEALTH
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -15,9 +16,10 @@ class Health (
     id: UUID = UuidCreator.create(),
     temperature: Double,
     memo: String,
+    baby: Baby,
     itemType: CareHistoryItemType = HEALTH,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Comment("체온")
     var temperature: Double = temperature
         protected set

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Sleep.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Sleep.kt
@@ -3,6 +3,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.SLEEP
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -17,9 +18,10 @@ class Sleep (
     minutes: Int,
     startTime: LocalDateTime,
     endTime: LocalDateTime,
+    baby: Baby,
     itemType: CareHistoryItemType = SLEEP,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Column(nullable = false)
     @Comment("[Not Null] 수면 시작 시간")
     var startTime: LocalDateTime = startTime

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Snack.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/domain/Snack.kt
@@ -2,6 +2,7 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import jakarta.persistence.Entity
 import jakarta.persistence.Table
+import kr.co.vacgom.api.baby.domain.Baby
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType.SNACK
 import kr.co.vacgom.api.global.util.UuidCreator
@@ -14,9 +15,10 @@ import java.util.*
 class Snack (
     id: UUID = UuidCreator.create(),
     memo: String,
+    baby: Baby,
     itemType: CareHistoryItemType = SNACK,
     executionTime: LocalDateTime,
-): CareHistoryItem(id, executionTime, itemType) {
+): CareHistoryItem(id, executionTime, itemType, baby) {
     @Comment("메모")
     var memo: String? = memo
         protected set

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/repository/CareHistoryItemAdapter.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/repository/CareHistoryItemAdapter.kt
@@ -20,7 +20,8 @@ class CareHistoryItemAdapter(
         val startExecutionDateTime = LocalDateTime.of(executionDate, LocalTime.MIN)
         val endExecutionDateTime = LocalDateTime.of(executionDate, LocalTime.MAX)
 
-        val careHistoryItems = careHistoryItemJpaRepository.findByExecutionTimeBetween(
+        val careHistoryItems = careHistoryItemJpaRepository.findByBabyIdAndExecutionTimeBetween(
+            babyId,
             startExecutionDateTime,
             endExecutionDateTime
         )

--- a/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/repository/CareHistoryItemJpaRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/carehistoryitem/repository/CareHistoryItemJpaRepository.kt
@@ -3,8 +3,8 @@ package kr.co.vacgom.api.carehistoryitem.repository
 import kr.co.vacgom.api.carehistoryitem.domain.CareHistoryItem
 import org.springframework.data.jpa.repository.JpaRepository
 import java.time.LocalDateTime
+import java.util.*
 
 interface CareHistoryItemJpaRepository : JpaRepository<CareHistoryItem, Long> {
-
-    fun findByExecutionTimeBetween(startExecutionDate: LocalDateTime, endExecutionDate: LocalDateTime): List<CareHistoryItem>
+    fun findByBabyIdAndExecutionTimeBetween(babyId: UUID, startExecutionDate: LocalDateTime, endExecutionDate: LocalDateTime): List<CareHistoryItem>
 }

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFoodTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFoodTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BabyFoodTest : FunSpec({
@@ -10,8 +13,16 @@ class BabyFoodTest : FunSpec({
         val amount = 100
         val executionTime = LocalDateTime.now()
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val babyFood = BabyFood(
             amount = amount,
+            baby = baby,
             executionTime = executionTime,
             itemType = CareHistoryItemType.BABY_FOOD
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFormulaTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BabyFormulaTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BabyFormulaTest : FunSpec({
@@ -10,8 +13,16 @@ class BabyFormulaTest : FunSpec({
         val amount = 100
         val executionTime = LocalDateTime.now()
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val babyFormula = BabyFormula(
             amount = amount,
+            baby = baby,
             executionTime = executionTime,
             itemType = CareHistoryItemType.BABY_FOOD
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BathTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BathTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
@@ -11,10 +14,18 @@ class BathTest : FunSpec({
         val startTime = LocalDateTime.now()
         val endTime = LocalDateTime.now().plusMinutes(30)
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val bath = Bath(
             startTime = startTime,
             endTime = endTime,
             minutes = ChronoUnit.MINUTES.between(startTime, endTime).toInt(),
+            baby = baby,
             executionTime = startTime,
             itemType = CareHistoryItemType.BATH
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastFeedingTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastFeedingTest.kt
@@ -2,8 +2,11 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.BreastDirection
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BreastFeedingTest : FunSpec({
@@ -13,11 +16,19 @@ class BreastFeedingTest : FunSpec({
         val minutes = 10
         val breastDirection = BreastDirection.LEFT
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val breastFeeding = BreastFeeding(
             startTime = startTime,
             endTime = endTime,
             minutes = minutes,
             breastDirection = breastDirection,
+            baby = baby,
             executionTime = startTime,
             itemType = CareHistoryItemType.BATH
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastPumpingTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/BreastPumpingTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class BreastPumpingTest : FunSpec({
@@ -10,8 +13,16 @@ class BreastPumpingTest : FunSpec({
         val amount = 100
         val executionTime = LocalDateTime.now()
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val breastPumping = BreastPumping(
             amount = amount,
+            baby = baby,
             itemType = CareHistoryItemType.BREAST_PUMPING,
             executionTime = executionTime
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/DiaperTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/DiaperTest.kt
@@ -2,8 +2,11 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
 import kr.co.vacgom.api.carehistoryitem.domain.enums.ExcrementType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class DiaperTest : FunSpec({
@@ -11,8 +14,16 @@ class DiaperTest : FunSpec({
         val excrementType = ExcrementType.POO
         val executionTime = LocalDateTime.now()
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val diaper = Diaper(
             excrementType = excrementType,
+            baby = baby,
             itemType = CareHistoryItemType.DIAPER,
             executionTime = executionTime
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/HealthTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/HealthTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class HealthTest : FunSpec({
@@ -11,9 +14,17 @@ class HealthTest : FunSpec({
         val memo = "정상 온도넹"
         val executionTime = LocalDateTime.now()
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val health = Health(
             temperature = temperature,
             memo = memo,
+            baby = baby,
             itemType = CareHistoryItemType.DIAPER,
             executionTime = executionTime
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/SleepTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/SleepTest.kt
@@ -2,7 +2,10 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SleepTest : FunSpec({
@@ -11,10 +14,18 @@ class SleepTest : FunSpec({
         val endTime = LocalDateTime.now().plusHours(8)
         val minutes = 30
 
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val sleep = Sleep(
             minutes = minutes,
             startTime = startTime,
             endTime = endTime,
+            baby = baby,
             itemType = CareHistoryItemType.SLEEP,
             executionTime = startTime
         )

--- a/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/SnackTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/carehistoryitem/domain/SnackTest.kt
@@ -2,15 +2,27 @@ package kr.co.vacgom.api.carehistoryitem.domain
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
 import kr.co.vacgom.api.carehistoryitem.domain.enums.CareHistoryItemType
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class SnackTest : FunSpec({
     test("Snack 객체 정상 생성 테스트") {
         val memo = "과자 5봉지나 먹음. 크게 성장할 듯"
         val executionTime = LocalDateTime.now()
+
+        val baby = Baby(
+            name = "백곰 아기",
+            profileImg = "아기 이미지",
+            gender = Gender.MALE,
+            birthday = LocalDate.now(),
+        )
+
         val snack = Snack(
             memo = memo,
+            baby = baby,
             itemType = CareHistoryItemType.SNACK,
             executionTime = executionTime
         )


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 Issue Ticket
- VACGOM-102

### 🔑 주요 작업사항
- 육아 기록 아이템 엔티티 아기 연관관계 추가
- 육아 기록 조회 시 아기 연관관계 필터링 추가
- 육아 기록 생성 시 아기 연관관계 정보 추가

### 🏞 (Optional) 참고 자료
- 

### (중요) 서브모듈이 수정되었나요?
- 기존 커밋 : 
- 변경 커밋 :
- 변경 사항 : 
- [] 해당 서브모듈 변경사항이 PR에 잘 반영되었나요?

### 꼭 확인해 주세요!!
-
