### PR TITLE
[Vacgom-104] 초대 코드 API 아기 데이터 조회 기능 변경

### DIFF
--- a/src/main/kotlin/kr/co/vacgom/api/baby/presentation/dto/BabyDto.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/presentation/dto/BabyDto.kt
@@ -1,0 +1,17 @@
+package kr.co.vacgom.api.baby.presentation.dto
+
+import kr.co.vacgom.api.baby.domain.enums.Gender
+import java.time.LocalDate
+import java.util.*
+
+class BabyDto {
+    class Response {
+        data class Detail(
+            val id: UUID,
+            val name: String,
+            val profileImg: String?,
+            val gender: Gender,
+            val birthday: LocalDate,
+        )
+    }
+}

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/application/BabyManagerService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/application/BabyManagerService.kt
@@ -14,6 +14,10 @@ class BabyManagerService(
         return babyManagerRepository.saveAll(managers)
     }
 
+    fun getBabyByIdAndUserIsAdmin(userId: UUID, babyId: UUID): Baby {
+        return babyManagerRepository.findByBabyIdAndUserIdAndAdminIs(userId, babyId, true).baby
+    }
+
     fun getBabiesByUserIsAdmin(userId: UUID): List<Baby> {
         return babyManagerRepository.findByUserIdAndAdminIs(userId, true).map { it.baby }
     }

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/exception/BabyManagerError.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/exception/BabyManagerError.kt
@@ -1,0 +1,14 @@
+package kr.co.vacgom.api.babymanager.exception
+
+import kr.co.vacgom.api.global.exception.error.ErrorCode
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatus.NOT_FOUND
+
+enum class BabyManagerError(
+    override val message: String,
+    override val status: HttpStatus,
+    override val code: String,
+) : ErrorCode {
+    BABY_MANAGER_NOT_FOUND("아기 돌보미가 존재하지 않습니다.", NOT_FOUND, "BM_001"),
+    NOT_ADMIN_BABY_MANAGER("아기의 대표 돌보미가 아닙니다.", NOT_FOUND, "BM_002"),
+}

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerJpaRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerJpaRepository.kt
@@ -15,5 +15,5 @@ interface BabyManagerJpaRepository: JpaRepository<BabyManager, UUID> {
         @Param("userId") userId: UUID,
         @Param("babyId") babyId: UUID,
         @Param("isAdmin")isAdmin: Boolean
-    ): BabyManager
+    ): BabyManager?
 }

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerJpaRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerJpaRepository.kt
@@ -9,4 +9,11 @@ import java.util.*
 interface BabyManagerJpaRepository: JpaRepository<BabyManager, UUID> {
     @Query("select bm from BabyManager bm where bm.user.id = :userId and bm.isAdmin = :isAdmin")
     fun findByUserIdAndAdminIs(@Param("userId") userId: UUID, @Param("isAdmin")isAdmin: Boolean): List<BabyManager>
+
+    @Query("select bm from BabyManager bm where bm.user.id = :userId and bm.baby.id = :babyId and bm.isAdmin = :isAdmin")
+    fun findByBabyIdAndUserIdAndAdminIs(
+        @Param("userId") userId: UUID,
+        @Param("babyId") babyId: UUID,
+        @Param("isAdmin")isAdmin: Boolean
+    ): BabyManager
 }

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepository.kt
@@ -7,4 +7,5 @@ interface BabyManagerRepository {
     fun save(babyManager: BabyManager): BabyManager
     fun saveAll(managers: Collection<BabyManager>): List<BabyManager>
     fun findByUserIdAndAdminIs(userId: UUID, isAdmin: Boolean): List<BabyManager>
+    fun findByBabyIdAndUserIdAndAdminIs(userId: UUID, babyId: UUID, isAdmin: Boolean): BabyManager
 }

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepositoryAdapter.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepositoryAdapter.kt
@@ -19,4 +19,8 @@ class BabyManagerRepositoryAdapter(
     override fun findByUserIdAndAdminIs(userId: UUID, isAdmin: Boolean): List<BabyManager> {
         return babyManagerJpaRepository.findByUserIdAndAdminIs(userId, isAdmin)
     }
+
+    override fun findByBabyIdAndUserIdAndAdminIs(userId: UUID, babyId: UUID, isAdmin: Boolean): BabyManager {
+        return babyManagerJpaRepository.findByBabyIdAndUserIdAndAdminIs(userId, babyId, isAdmin)
+    }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepositoryAdapter.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/babymanager/repository/BabyManagerRepositoryAdapter.kt
@@ -1,6 +1,8 @@
 package kr.co.vacgom.api.babymanager.repository
 
 import kr.co.vacgom.api.babymanager.domain.BabyManager
+import kr.co.vacgom.api.babymanager.exception.BabyManagerError
+import kr.co.vacgom.api.global.exception.error.BusinessException
 import org.springframework.stereotype.Repository
 import java.util.*
 
@@ -22,5 +24,6 @@ class BabyManagerRepositoryAdapter(
 
     override fun findByBabyIdAndUserIdAndAdminIs(userId: UUID, babyId: UUID, isAdmin: Boolean): BabyManager {
         return babyManagerJpaRepository.findByBabyIdAndUserIdAndAdminIs(userId, babyId, isAdmin)
+            ?: throw BusinessException(BabyManagerError.NOT_ADMIN_BABY_MANAGER)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/application/InvitationService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/application/InvitationService.kt
@@ -5,7 +5,6 @@ import kr.co.vacgom.api.baby.presentation.dto.BabyDto
 import kr.co.vacgom.api.babymanager.application.BabyManagerService
 import kr.co.vacgom.api.global.exception.error.BusinessException
 import kr.co.vacgom.api.global.util.UuidCreator
-import kr.co.vacgom.api.invitation.domain.CareScope
 import kr.co.vacgom.api.invitation.domain.InvitationCode
 import kr.co.vacgom.api.invitation.exception.InvitationError
 import kr.co.vacgom.api.invitation.presentation.dto.InvitationDto
@@ -21,7 +20,19 @@ class InvitationService(
     private val babyService: BabyService,
 ) {
     @Transactional
-    fun createInvitationCode(userId: UUID, careScope: CareScope): InvitationDto.Response.Create {
+    fun createInvitationCodeByBabyId(userId: UUID, babyId: UUID): InvitationDto.Response.Create {
+        val key = UuidCreator.create().toString()
+
+        listOf(babyManagerService.getBabyByIdAndUserIsAdmin(userId, babyId))
+            .map { baby -> baby.id }
+            .let { babyIds -> InvitationCode(key = key, userId = userId, babyIds = babyIds) }
+            .also { invitationCode -> invitationRepository.save(invitationCode, invitationCode.timeToLive) }
+
+        return InvitationDto.Response.Create(invitationCode = key)
+    }
+
+    @Transactional
+    fun createInvitationCodeByUserIsAdmin(userId: UUID): InvitationDto.Response.Create {
         val key = UuidCreator.create().toString()
 
         babyManagerService.getBabiesByUserIsAdmin(userId)

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/application/InvitationService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/application/InvitationService.kt
@@ -1,8 +1,8 @@
 package kr.co.vacgom.api.invitation.application
 
 import kr.co.vacgom.api.baby.application.BabyService
+import kr.co.vacgom.api.baby.presentation.dto.BabyDto
 import kr.co.vacgom.api.babymanager.application.BabyManagerService
-import kr.co.vacgom.api.babymanager.domain.BabyManager
 import kr.co.vacgom.api.global.exception.error.BusinessException
 import kr.co.vacgom.api.global.util.UuidCreator
 import kr.co.vacgom.api.invitation.domain.CareScope
@@ -10,7 +10,6 @@ import kr.co.vacgom.api.invitation.domain.InvitationCode
 import kr.co.vacgom.api.invitation.exception.InvitationError
 import kr.co.vacgom.api.invitation.presentation.dto.InvitationDto
 import kr.co.vacgom.api.invitation.repository.InvitationRepository
-import kr.co.vacgom.api.user.application.UserService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.util.*
@@ -20,7 +19,6 @@ class InvitationService(
     private val invitationRepository: InvitationRepository,
     private val babyManagerService: BabyManagerService,
     private val babyService: BabyService,
-    private val userService: UserService,
 ) {
     @Transactional
     fun createInvitationCode(userId: UUID, careScope: CareScope): InvitationDto.Response.Create {
@@ -35,19 +33,18 @@ class InvitationService(
     }
 
     @Transactional
-    fun registerInvitationCode(userId: UUID, code: String) {
+    fun getBabiesByInvitationCode(userId: UUID, code: String): List<BabyDto.Response.Detail> {
         val invitationCode = invitationRepository.getAndDeleteInvitationCode(code)
             ?: throw BusinessException(InvitationError.INVITATION_CODE_NOT_FOUND)
 
-        val newBabyManagers = babyService.getBabiesById(invitationCode.babyIds)
-            .map {
-                BabyManager(
-                    user = userService.getUserById(userId),
-                    baby = it,
-                    isAdmin = false,
-                )
-            }
-
-        babyManagerService.saveAll(newBabyManagers)
+        return babyService.getBabiesById(invitationCode.babyIds).map {
+            BabyDto.Response.Detail(
+                id = it.id,
+                name = it.name,
+                profileImg = it.profileImg,
+                gender = it.gender,
+                birthday = it.birthday,
+            )
+        }
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationApi.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationApi.kt
@@ -5,11 +5,12 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.tags.Tag
+import kr.co.vacgom.api.baby.presentation.dto.BabyDto
 import kr.co.vacgom.api.global.common.dto.BaseResponse
 import kr.co.vacgom.api.global.exception.error.ErrorResponse
 import kr.co.vacgom.api.invitation.presentation.dto.InvitationDto
 
-@Tag(name = "초대 코드 API(내부 로직 수정 예정 사용 X)")
+@Tag(name = "초대 코드 API")
 interface InvitationApi {
     @Operation(
         summary = "초대 코드 생성 API",
@@ -23,15 +24,15 @@ interface InvitationApi {
     fun createInvitationCode(request: InvitationDto.Request.Create): BaseResponse<InvitationDto.Response.Create>
 
     @Operation(
-        summary = "초대 코드 등록 API",
-        operationId = "registerInvitationCode",
+        summary = "초대 코드 조회 API",
+        operationId = "getBabiesByInvitationCode",
         description = """""",
         responses = [
             ApiResponse(responseCode = "200", description = ""),
             ApiResponse(responseCode = "400", description = "Bad Request", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
         ]
     )
-    fun registerInvitationCode(request: InvitationDto.Request.Register)
+    fun getBabiesByInvitationCode(request: InvitationDto.Request.Get): List<BabyDto.Response.Detail>
 
 
     companion object {

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationApi.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationApi.kt
@@ -32,7 +32,7 @@ interface InvitationApi {
             ApiResponse(responseCode = "400", description = "Bad Request", content = [Content(schema = Schema(implementation = ErrorResponse::class))]),
         ]
     )
-    fun getBabiesByInvitationCode(request: InvitationDto.Request.Get): List<BabyDto.Response.Detail>
+    fun getBabiesByInvitationCode(request: InvitationDto.Request.Get): BaseResponse<List<BabyDto.Response.Detail>>
 
 
     companion object {

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationController.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationController.kt
@@ -21,14 +21,17 @@ class InvitationController(
     override fun createInvitationCode(@RequestBody request: InvitationDto.Request.Create): BaseResponse<InvitationDto.Response.Create> {
         val userId = SecurityContextUtil.getPrincipal()
 
-        return BaseResponse.success {
-            invitationService.createInvitationCode(userId, request.careScope)
-        }
+        return when(request.babyId) {
+            null -> invitationService.createInvitationCodeByUserIsAdmin(userId)
+            else -> invitationService.createInvitationCodeByBabyId(userId, request.babyId)
+        }.let { BaseResponse.success(it) }
     }
 
     @PostMapping
-    override fun getBabiesByInvitationCode(@RequestBody request: InvitationDto.Request.Get): List<BabyDto.Response.Detail> {
+    override fun getBabiesByInvitationCode(@RequestBody request: InvitationDto.Request.Get): BaseResponse<List<BabyDto.Response.Detail>> {
         val userId = SecurityContextUtil.getPrincipal()
+
         return invitationService.getBabiesByInvitationCode(userId, request.invitationCode)
+            .let { BaseResponse.success(it) }
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationController.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/InvitationController.kt
@@ -1,6 +1,7 @@
 package kr.co.vacgom.api.invitation.presentation
 
 import kr.co.vacgom.api.auth.security.util.SecurityContextUtil
+import kr.co.vacgom.api.baby.presentation.dto.BabyDto
 import kr.co.vacgom.api.global.common.dto.BaseResponse
 import kr.co.vacgom.api.global.presentation.GlobalPath.BASE_V3
 import kr.co.vacgom.api.invitation.application.InvitationService
@@ -26,8 +27,8 @@ class InvitationController(
     }
 
     @PostMapping
-    override fun registerInvitationCode(@RequestBody request: InvitationDto.Request.Register) {
+    override fun getBabiesByInvitationCode(@RequestBody request: InvitationDto.Request.Get): List<BabyDto.Response.Detail> {
         val userId = SecurityContextUtil.getPrincipal()
-        invitationService.registerInvitationCode(userId, request.invitationCode)
+        return invitationService.getBabiesByInvitationCode(userId, request.invitationCode)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/dto/InvitationDto.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/dto/InvitationDto.kt
@@ -7,8 +7,8 @@ class InvitationDto {
     class Request {
         @Schema(name = "InvitationDto.Request.Create")
         data class Create(val careScope: CareScope)
-        @Schema(name = "InvitationDto.Request.Register")
-        data class Register(val invitationCode: String)
+        @Schema(name = "InvitationDto.Request.Get")
+        data class Get(val invitationCode: String)
     }
 
     class Response {

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/dto/InvitationDto.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/presentation/dto/InvitationDto.kt
@@ -1,12 +1,15 @@
 package kr.co.vacgom.api.invitation.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
-import kr.co.vacgom.api.invitation.domain.CareScope
+import java.util.*
 
 class InvitationDto {
     class Request {
         @Schema(name = "InvitationDto.Request.Create")
-        data class Create(val careScope: CareScope)
+        data class Create(
+            val babyId: UUID?,
+        )
+
         @Schema(name = "InvitationDto.Request.Get")
         data class Get(val invitationCode: String)
     }

--- a/src/main/kotlin/kr/co/vacgom/api/redis/RedissonConfig.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/redis/RedissonConfig.kt
@@ -14,7 +14,7 @@ import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSeriali
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
 @Configuration
-private class RedissonConfig(
+class RedissonConfig(
     @Value("\${redis.host}")
     private val host: String,
 

--- a/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserApi.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserApi.kt
@@ -41,7 +41,7 @@ interface UserApi {
         description = """
             엑세스 토큰 필요 X
             request -> Content-Type: application/json
-            babyImages -> Content-Type: multipart/form-data
+            profileImg -> Content-Type: multipart/form-data
         """,
         responses = [
             ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = SignupDto.Response::class))]),

--- a/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
@@ -1,0 +1,153 @@
+package kr.co.vacgom.api.invitation.application
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.every
+import io.mockk.mockk
+import kr.co.vacgom.api.auth.oauth.enums.SocialLoginProvider
+import kr.co.vacgom.api.baby.application.BabyService
+import kr.co.vacgom.api.baby.domain.Baby
+import kr.co.vacgom.api.baby.domain.enums.Gender
+import kr.co.vacgom.api.babymanager.application.BabyManagerService
+import kr.co.vacgom.api.babymanager.domain.BabyManager
+import kr.co.vacgom.api.babymanager.exception.BabyManagerError
+import kr.co.vacgom.api.global.exception.error.BusinessException
+import kr.co.vacgom.api.global.util.UuidCreator
+import kr.co.vacgom.api.invitation.domain.InvitationCode
+import kr.co.vacgom.api.invitation.exception.InvitationError
+import kr.co.vacgom.api.invitation.repository.InvitationRepository
+import kr.co.vacgom.api.user.domain.User
+import kr.co.vacgom.api.user.domain.enums.UserRole
+import java.time.LocalDate
+import java.util.*
+
+class InvitationServiceTest : DescribeSpec({
+    val invitationRepositoryMock: InvitationRepository = mockk(relaxed = true)
+    val babyManagerServiceMock: BabyManagerService = mockk(relaxed = true)
+    val babyServiceMock: BabyService = mockk(relaxed = true)
+
+    val sut = InvitationService(
+        invitationRepositoryMock,
+        babyManagerServiceMock,
+        babyServiceMock,
+    )
+
+    describe("초대 코드 생성 테스트") {
+        val adminUser = User(
+            nickname = "nickname",
+            socialId = "socialId",
+            provider = SocialLoginProvider.KAKAO,
+            role = UserRole.ROLE_USER,
+        )
+
+        val babies = enumValues<Gender>().map {
+            Baby(
+                name = "babyName",
+                profileImg = "profileImg",
+                gender = it,
+                birthday = LocalDate.now(),
+            )
+        }
+
+        val babyManagers = babies.map {
+            BabyManager(
+                user = adminUser,
+                baby = it,
+                isAdmin = true
+            )
+        }
+
+        context("유저가 대표 돌보미로 존재하는 모든 아기에 대한 초대 코드를 생성한다면") {
+            it("초대 코드가 생성된다.") {
+                every { babyManagerServiceMock.getBabiesByUserIsAdmin(adminUser.id) } returns babies
+
+                val result = sut.createInvitationCodeByUserIsAdmin(adminUser.id)
+
+                result.invitationCode.shouldNotBeEmpty()
+                result.invitationCode.shouldBeTypeOf<String>()
+                UUID.fromString(result.invitationCode).shouldBeTypeOf<UUID>()
+            }
+        }
+
+        context("유저가 대표 돌보미로 존재하는 한 명의 아기에 대한 초대 코드를 생성한다면") {
+            it("초대 코드가 생성된다.") {
+                every { babyManagerServiceMock.getBabyByIdAndUserIsAdmin(adminUser.id, babies[0].id) } returns babies[0]
+
+                val result = sut.createInvitationCodeByBabyId(adminUser.id, babies[0].id)
+
+                result.invitationCode.shouldNotBeEmpty()
+                result.invitationCode.shouldBeTypeOf<String>()
+                UUID.fromString(result.invitationCode).shouldBeTypeOf<UUID>()
+            }
+        }
+
+        context("유저가 초대 코드를 생성하고자 하는 아기의 대표 돌보미가 아닌 경우") {
+            it("${BabyManagerError.NOT_ADMIN_BABY_MANAGER} 예외가 발생한다.") {
+                every {
+                    babyManagerServiceMock.getBabyByIdAndUserIsAdmin(adminUser.id, babies[0].id)
+                } throws BusinessException(BabyManagerError.NOT_ADMIN_BABY_MANAGER)
+
+                val result = shouldThrow<BusinessException> { sut.createInvitationCodeByBabyId(adminUser.id, babies[0].id) }
+
+                result.errorCode shouldBe BabyManagerError.NOT_ADMIN_BABY_MANAGER
+            }
+        }
+    }
+
+    describe("초대 코드 조회 테스트") {
+        val adminUser = User(
+            nickname = "nickname",
+            socialId = "socialId",
+            provider = SocialLoginProvider.KAKAO,
+            role = UserRole.ROLE_USER,
+        )
+
+        val babies = enumValues<Gender>().map {
+            Baby(
+                name = "babyName",
+                profileImg = "profileImg",
+                gender = it,
+                birthday = LocalDate.now(),
+            )
+        }
+
+        val invitationCode = InvitationCode(
+            key = UuidCreator.create().toString(),
+            userId = adminUser.id,
+            babyIds = babies.map { it.id },
+        )
+
+        context("초대 코드를 정상적으로 조회한다면") {
+            it("해당하는 아기 상세 정보를 반환한다.") {
+                every { invitationRepositoryMock.getAndDeleteInvitationCode(invitationCode.key) } returns invitationCode
+                every { babyServiceMock.getBabiesById(babies.map { it.id }) } returns babies
+
+                val result = sut.getBabiesByInvitationCode(adminUser.id, invitationCode.key)
+
+                result.forEachIndexed { index, detail ->
+                    detail.id shouldBe babies[index].id
+                    detail.name shouldBe babies[index].name
+                    detail.profileImg shouldBe babies[index].profileImg
+                    detail.gender shouldBe babies[index].gender
+                    detail.birthday shouldBe babies[index].birthday
+                }
+            }
+        }
+
+        context("초대 코드가 존재하지 않는다면") {
+            it("${InvitationError.INVITATION_CODE_NOT_FOUND} 예외가 발생한다.") {
+                every {
+                    invitationRepositoryMock.getAndDeleteInvitationCode(invitationCode.key)
+                } throws BusinessException(InvitationError.INVITATION_CODE_NOT_FOUND)
+
+                val result = shouldThrow<BusinessException> { sut.getBabiesByInvitationCode(adminUser.id, invitationCode.key) }
+
+                result.errorCode shouldBe InvitationError.INVITATION_CODE_NOT_FOUND
+            }
+        }
+    }
+
+})

--- a/src/test/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCodeTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCodeTest.kt
@@ -1,0 +1,43 @@
+package kr.co.vacgom.api.invitation.domain
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import kr.co.vacgom.api.global.util.UuidCreator
+
+class InvitationCodeTest : FunSpec({
+
+    test("InvitationCode 객체 정상 생성 테스트(TTL 지정 X)") {
+        val key = UuidCreator.create().toString()
+        val userId = UuidCreator.create()
+        val babyIds = listOf(UuidCreator.create(), UuidCreator.create())
+
+        val invitationCode = InvitationCode(
+            key = key,
+            userId = userId,
+            babyIds = babyIds
+        )
+
+        invitationCode.key shouldBe key
+        invitationCode.userId shouldBe userId
+        invitationCode.babyIds shouldBe babyIds
+    }
+
+    test("InvitationCode 객체 정상 생성 테스트(TTL 지정 O)") {
+        val key = UuidCreator.create().toString()
+        val userId = UuidCreator.create()
+        val babyIds = listOf(UuidCreator.create(), UuidCreator.create())
+        val ttl = 100L
+
+        val invitationCode = InvitationCode(
+            key = key,
+            userId = userId,
+            babyIds = babyIds,
+            timeToLive = ttl
+        )
+
+        invitationCode.key shouldBe key
+        invitationCode.userId shouldBe userId
+        invitationCode.babyIds shouldBe babyIds
+        invitationCode.timeToLive shouldBe ttl
+    }
+})

--- a/src/test/kotlin/kr/co/vacgom/api/user/application/AuthServiceTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/user/application/AuthServiceTest.kt
@@ -16,7 +16,6 @@ import kr.co.vacgom.api.user.presentation.dto.LoginDto
 import kr.co.vacgom.api.user.repository.UserRepository
 
 class AuthServiceTest : DescribeSpec({
-
     val oauthHandlerMock: OAuthHandler = mockk(relaxed = true)
     val userTokenServiceMock: UserTokenService = mockk(relaxed = true)
     val userRepositoryMock: UserRepository = mockk(relaxed = true)


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 Issue Ticket
- VACGOM-104

### 🔑 주요 작업사항
- 초대 코드 생성 API 아기 한 명, 전체 초대 기능 구분
- 초대 코드로 아기 데이터 조회할 수 있도록 기능 리팩토링

### 🏞 (Optional) 참고 자료
- 

### (중요) 서브모듈이 수정되었나요?
- 기존 커밋 : 
- 변경 커밋 :
- 변경 사항 : 
- [] 해당 서브모듈 변경사항이 PR에 잘 반영되었나요?

### 꼭 확인해 주세요!!
-
