### PR TITLE
[Vacgom-113] 아기 이미지 업로드 API 구현 및 회원가입 API 이미지 URL 전달 리팩토링

### DIFF
--- a/.github/workflows/CI-DEV.yml
+++ b/.github/workflows/CI-DEV.yml
@@ -1,0 +1,35 @@
+name: CI-dev
+
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '21'
+          distribution: 'corretto'
+
+      - name: Gradle Caching
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+      - name: Grant Execute Permission For Gradlew
+        run: chmod +x gradlew
+
+      - name: Build With Gradle
+        run: |
+          ./gradlew build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     // JWT
     implementation("com.auth0:java-jwt:4.4.0")
 
+    // coroutine
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.1")
+
     annotationProcessor("org.springframework.boot:spring-boot-configuration-processor")
 }
 

--- a/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyImageService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyImageService.kt
@@ -1,0 +1,40 @@
+package kr.co.vacgom.api.baby.application
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kr.co.vacgom.api.global.util.UuidCreator
+import kr.co.vacgom.api.s3.S3Service
+import org.apache.tomcat.util.http.fileupload.InvalidFileNameException
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.web.multipart.MultipartFile
+
+@Service
+class BabyImageService(
+    @Value("\${spring.cloud.aws.cloud-front.cdn}")
+    private val cdnUrl: String,
+    private val s3Service: S3Service,
+) {
+    fun uploadBabyImages(images: List<MultipartFile>): List<String> {
+
+        return images.map {
+            val path = "${BABY_PROFILE_DIR}${UuidCreator.create()}.${extractExt(it)}"
+
+            CoroutineScope(Dispatchers.IO).launch {
+                s3Service.uploadImage(path, it)
+            }
+
+            "${cdnUrl}/${path}"
+        }
+    }
+
+    private fun extractExt(file: MultipartFile): String {
+        file.originalFilename?.let { return it.substringAfterLast(".") }
+            ?: throw InvalidFileNameException(file.originalFilename, "파일 이름이 존재하지 않습니다.")
+    }
+
+    companion object {
+        const val BABY_PROFILE_DIR = "baby_profile/"
+    }
+}

--- a/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/application/BabyService.kt
@@ -9,7 +9,7 @@ import java.util.*
 @Service
 @Transactional
 class BabyService(
-    private val babyRepository: BabyRepository
+    private val babyRepository: BabyRepository,
 ) {
     fun saveAll(babies: List<Baby>): List<Baby> {
         return babyRepository.saveAll(babies)

--- a/src/main/kotlin/kr/co/vacgom/api/baby/presentation/BabyApi.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/presentation/BabyApi.kt
@@ -1,0 +1,32 @@
+package kr.co.vacgom.api.baby.presentation
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.co.vacgom.api.baby.presentation.dto.BabyDto
+import kr.co.vacgom.api.global.common.dto.BaseResponse
+import kr.co.vacgom.api.global.exception.error.ErrorResponse
+
+@Tag(name = "아기 API")
+interface BabyApi {
+    @Operation(
+        summary = "아기 프로필 이미지 업로드 API",
+        operationId = "uploadBabyImage",
+        description = """""",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK"),
+            ApiResponse(
+                responseCode = "400",
+                description = "Bad Request",
+                content = [Content(schema = Schema(implementation = ErrorResponse::class))]
+            ),
+        ]
+    )
+    fun uploadBabyImage(request: BabyDto.Request.UploadImage): BaseResponse<List<String>>
+
+    companion object {
+        const val BABY = "/babies"
+    }
+}

--- a/src/main/kotlin/kr/co/vacgom/api/baby/presentation/BabyController.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/presentation/BabyController.kt
@@ -1,0 +1,24 @@
+package kr.co.vacgom.api.baby.presentation
+
+import kr.co.vacgom.api.baby.application.BabyImageService
+import kr.co.vacgom.api.baby.application.BabyService
+import kr.co.vacgom.api.baby.presentation.BabyApi.Companion.BABY
+import kr.co.vacgom.api.baby.presentation.dto.BabyDto
+import kr.co.vacgom.api.global.common.dto.BaseResponse
+import kr.co.vacgom.api.global.presentation.GlobalPath.BASE_V3
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping(BASE_V3 + BABY)
+class BabyController(
+    private val babyService: BabyService,
+    private val babyImageService: BabyImageService,
+): BabyApi {
+    @PostMapping("/images")
+    override fun uploadBabyImage(@ModelAttribute request: BabyDto.Request.UploadImage): BaseResponse<List<String>> {
+        return babyImageService.uploadBabyImages(request.images).let { BaseResponse.success(it) }
+    }
+}

--- a/src/main/kotlin/kr/co/vacgom/api/baby/presentation/dto/BabyDto.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/baby/presentation/dto/BabyDto.kt
@@ -1,10 +1,17 @@
 package kr.co.vacgom.api.baby.presentation.dto
 
 import kr.co.vacgom.api.baby.domain.enums.Gender
+import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 import java.util.*
 
 class BabyDto {
+    class Request {
+        data class UploadImage(
+            val images: List<MultipartFile>,
+        )
+    }
+
     class Response {
         data class Detail(
             val id: UUID,

--- a/src/main/kotlin/kr/co/vacgom/api/s3/S3Service.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/s3/S3Service.kt
@@ -1,38 +1,22 @@
 package kr.co.vacgom.api.s3
 
-import io.awspring.cloud.s3.S3Exception
 import io.awspring.cloud.s3.S3Operations
-import kr.co.vacgom.api.global.util.UuidCreator
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Component
+import org.springframework.web.multipart.MultipartException
 import org.springframework.web.multipart.MultipartFile
 
 @Component
 class S3Service(
     @Value("\${spring.cloud.aws.s3.bucket}")
     private val bucketName: String,
-    @Value("\${spring.cloud.aws.cloud-front.cdn}")
-    private val cdnUrl: String,
     private val s3Operation: S3Operations,
 ) {
-    fun uploadImage(file: MultipartFile?): String? {
+    fun uploadImage(path: String, file: MultipartFile?) {
         if (file == null || file.isEmpty) {
-            return null
+            throw MultipartException("파일이 비어있거나 null입니다.")
         }
 
-        return file.run {
-            val path = "${BABY_PROFILE_DIR}${UuidCreator.create()}.${extractExt(this)}"
-            val resource = s3Operation.upload(bucketName, path, inputStream)
-            "${cdnUrl}/${resource.filename}"
-        }
-    }
-
-    private fun extractExt(file: MultipartFile): String {
-        file.originalFilename?.let { return it.substringAfterLast(".") }
-            ?: throw S3Exception("Invalid file path", null)
-    }
-
-    companion object {
-        const val BABY_PROFILE_DIR = "baby_profile/"
+        s3Operation.upload(bucketName, path, file.inputStream)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/user/application/UserService.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/user/application/UserService.kt
@@ -39,7 +39,7 @@ class UserService(
         val newBabies = request.babies.map {
             Baby(
                 name = it.name,
-                profileImg = s3Service.uploadImage(it.profileImg),
+                profileImg = it.profileImg,
                 gender = it.gender,
                 birthday = it.birthday,
             )

--- a/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserApi.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserApi.kt
@@ -40,8 +40,6 @@ interface UserApi {
         operationId = "signup",
         description = """
             엑세스 토큰 필요 X
-            request -> Content-Type: application/json
-            profileImg -> Content-Type: multipart/form-data
         """,
         responses = [
             ApiResponse(responseCode = "200", description = "OK", content = [Content(schema = Schema(implementation = SignupDto.Response::class))]),

--- a/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserController.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/user/presentation/UserController.kt
@@ -21,7 +21,7 @@ class UserController(
     }
 
     @PostMapping
-    override fun signup(@ModelAttribute request: SignupDto.Request): BaseResponse<SignupDto.Response> {
+    override fun signup(@RequestBody request: SignupDto.Request): BaseResponse<SignupDto.Response> {
         return BaseResponse.success(userService.signup(request))
     }
 

--- a/src/main/kotlin/kr/co/vacgom/api/user/presentation/dto/SignupDto.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/user/presentation/dto/SignupDto.kt
@@ -2,7 +2,6 @@ package kr.co.vacgom.api.user.presentation.dto
 
 import io.swagger.v3.oas.annotations.media.Schema
 import kr.co.vacgom.api.baby.domain.enums.Gender
-import org.springframework.web.multipart.MultipartFile
 import java.time.LocalDate
 
 class SignupDto {
@@ -15,7 +14,7 @@ class SignupDto {
         data class Baby(
             val name: String,
             val gender: Gender,
-            val profileImg: MultipartFile?,
+            val profileImg: String?,
             val birthday: LocalDate,
         )
     }

--- a/src/test/kotlin/kr/co/vacgom/api/user/application/UserServiceTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/user/application/UserServiceTest.kt
@@ -76,7 +76,7 @@ class UserServiceTest: DescribeSpec( {
             SignupDto.Request.Baby(
                 "baby${it.ordinal}",
                 it,
-                null,
+                "profileImgUrl",
                 LocalDate.now()
             )
         }


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 Issue Ticket
- VACGOM-113

### 🔑 주요 작업사항
- 아기 이미지 업로드 API 구현
- 회원가입 API 이미지 파일 -> URL string 전달 방식으로 변경

### 🏞 (Optional) 참고 자료
- 

### (중요) 서브모듈이 수정되었나요?
- 기존 커밋 : 
- 변경 커밋 :
- 변경 사항 : 
- [] 해당 서브모듈 변경사항이 PR에 잘 반영되었나요?

### 꼭 확인해 주세요!!
-
