### PR TITLE
[Vacgom-119] 초대코드 조회 실패 시 레디스 롤백 예외 처리

### DIFF
--- a/src/main/kotlin/kr/co/vacgom/api/invitation/domain/CareScope.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/domain/CareScope.kt
@@ -1,5 +1,0 @@
-package kr.co.vacgom.api.invitation.domain
-
-enum class CareScope {
-    RESPECTIVE, TOTAL
-}

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCode.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCode.kt
@@ -7,7 +7,7 @@ data class InvitationCode(
     val key: String,
     val userId: UUID,
     val babyIds: List<UUID>,
-    val isExpired: Boolean = false,
+    var isExpired: Boolean = false,
     val timeToLive: Long = 86400L,
-    val createdAt: LocalDateTime = LocalDateTime.now()
+    val createdAt: LocalDateTime = LocalDateTime.now(),
 )

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCode.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/domain/InvitationCode.kt
@@ -7,6 +7,7 @@ data class InvitationCode(
     val key: String,
     val userId: UUID,
     val babyIds: List<UUID>,
+    val isExpired: Boolean = false,
     val timeToLive: Long = 86400L,
     val createdAt: LocalDateTime = LocalDateTime.now()
 )

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRedisRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRedisRepository.kt
@@ -18,14 +18,25 @@ class InvitationRedisRepository(
             .also { value -> redisTemplate.opsForValue().set(key, value, ttl, TimeUnit.SECONDS)}
     }
 
-    fun getAndDeleteInvitationCode(code: String): InvitationCode? {
-        val queryKey = INVITATION_CODE_KEY_PREFIX + code
-        val value = redisTemplate.opsForValue().getAndDelete(queryKey)
-
-        return objectMapper.readValue(value.toString(), InvitationCode::class.java)
+    fun getInvitationCodeAndUpdateExpired(code: String): InvitationCode? {
+        val key = INVITATION_CODE_KEY_PREFIX + code
+        return redisTemplate.execute { getInvitationCodeAndUpdateExpired(key, true) }
     }
 
-    companion object{
+    fun rollBackExpiredInvitationCode(code: String) {
+        val key = INVITATION_CODE_KEY_PREFIX + code
+        redisTemplate.execute { getInvitationCodeAndUpdateExpired(key, false) }
+    }
+
+    private fun getInvitationCodeAndUpdateExpired(key: String, expireStatus: Boolean): InvitationCode? {
+        val value = redisTemplate.opsForValue().get(key) ?: return null
+
+        return objectMapper.readValue(value.toString(), InvitationCode::class.java)
+            .apply { isExpired = expireStatus }
+            .also { redisTemplate.opsForValue().set(key, objectMapper.writeValueAsString(it)) }
+    }
+
+    companion object {
         const val INVITATION_CODE_KEY_PREFIX = "invitation_code:"
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRepository.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRepository.kt
@@ -4,5 +4,6 @@ import kr.co.vacgom.api.invitation.domain.InvitationCode
 
 interface InvitationRepository {
     fun save(invitationCode: InvitationCode, ttl: Long)
-    fun getAndDeleteInvitationCode(code: String): InvitationCode?
+    fun getInvitationCodeAndUpdateExpired(code: String): InvitationCode
+    fun rollBackInvitationCodeExpired(code: String)
 }

--- a/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRepositoryAdapter.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/invitation/repository/InvitationRepositoryAdapter.kt
@@ -1,6 +1,8 @@
 package kr.co.vacgom.api.invitation.repository
 
+import kr.co.vacgom.api.global.exception.error.BusinessException
 import kr.co.vacgom.api.invitation.domain.InvitationCode
+import kr.co.vacgom.api.invitation.exception.InvitationError
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -11,7 +13,12 @@ class InvitationRepositoryAdapter(
         invitationRedisRepository.save(invitationCode, ttl)
     }
 
-    override fun getAndDeleteInvitationCode(code: String): InvitationCode? {
-        return invitationRedisRepository.getAndDeleteInvitationCode(code)
+    override fun getInvitationCodeAndUpdateExpired(code: String): InvitationCode {
+        return invitationRedisRepository.getInvitationCodeAndUpdateExpired(code) ?:
+            throw BusinessException(InvitationError.INVITATION_CODE_NOT_FOUND)
+    }
+
+    override fun rollBackInvitationCodeExpired(code: String) {
+        invitationRedisRepository.rollBackExpiredInvitationCode(code)
     }
 }

--- a/src/main/kotlin/kr/co/vacgom/api/redis/RedissonConfig.kt
+++ b/src/main/kotlin/kr/co/vacgom/api/redis/RedissonConfig.kt
@@ -42,14 +42,7 @@ class RedissonConfig(
             connectionFactory = redisConnectionFactory
             keySerializer = StringRedisSerializer()
             valueSerializer = serializer
+            setEnableTransactionSupport(true)
         }
     }
-
-//    @Bean
-//    fun objectMapper(): ObjectMapper {
-//        return ObjectMapper().apply {
-//            registerModule(KotlinModule.Builder().build())
-//            registerModule(JavaTimeModule())
-//        }
-//    }
 }

--- a/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
@@ -122,7 +122,7 @@ class InvitationServiceTest : DescribeSpec({
 
         context("초대 코드를 정상적으로 조회한다면") {
             it("해당하는 아기 상세 정보를 반환한다.") {
-                every { invitationRepositoryMock.getAndDeleteInvitationCode(invitationCode.key) } returns invitationCode
+                every { invitationRepositoryMock.getInvitationCodeAndUpdateExpired(invitationCode.key) } returns invitationCode
                 every { babyQueryServiceMock.getBabiesById(babies.map { it.id }) } returns babies
 
                 val result = sut.getBabiesByInvitationCode(invitationCode.key)
@@ -140,7 +140,7 @@ class InvitationServiceTest : DescribeSpec({
         context("초대 코드가 존재하지 않는다면") {
             it("${InvitationError.INVITATION_CODE_NOT_FOUND} 예외가 발생한다.") {
                 every {
-                    invitationRepositoryMock.getAndDeleteInvitationCode(invitationCode.key)
+                    invitationRepositoryMock.getInvitationCodeAndUpdateExpired(invitationCode.key)
                 } throws BusinessException(InvitationError.INVITATION_CODE_NOT_FOUND)
 
                 val result = shouldThrow<BusinessException> { sut.getBabiesByInvitationCode(invitationCode.key) }

--- a/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
+++ b/src/test/kotlin/kr/co/vacgom/api/invitation/application/InvitationServiceTest.kt
@@ -21,6 +21,7 @@ import kr.co.vacgom.api.invitation.exception.InvitationError
 import kr.co.vacgom.api.invitation.repository.InvitationRepository
 import kr.co.vacgom.api.user.domain.User
 import kr.co.vacgom.api.user.domain.enums.UserRole
+import org.slf4j.Logger
 import java.time.LocalDate
 import java.util.*
 
@@ -28,11 +29,13 @@ class InvitationServiceTest : DescribeSpec({
     val invitationRepositoryMock: InvitationRepository = mockk(relaxed = true)
     val babyManagerServiceMock: BabyManagerService = mockk(relaxed = true)
     val babyQueryServiceMock: BabyQueryService = mockk(relaxed = true)
+    val loggerMock: Logger = mockk(relaxed = true)
 
     val sut = InvitationService(
         invitationRepositoryMock,
         babyManagerServiceMock,
         babyQueryServiceMock,
+        logger = loggerMock
     )
 
     describe("초대 코드 생성 테스트") {


### PR DESCRIPTION
## <i>PULL REQUEST</i>

### 🎋 Issue Ticket
- VACGOM-119

### 🔑 주요 작업사항
- 초대 코드 조회 도중 예외 발생 시 Redis 서버 롤백 로직 구현

### 🏞 (Optional) 참고 자료
- 

### (중요) 서브모듈이 수정되었나요?
- 기존 커밋 : 
- 변경 커밋 :
- 변경 사항 : 
- [] 해당 서브모듈 변경사항이 PR에 잘 반영되었나요?

### 꼭 확인해 주세요!!
-
